### PR TITLE
Add `assetHost` config option for CDN users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ storage: {
     bucket: 'YOUR_BUCKET_NAME',
     region: 'YOUR_REGION_SLUG',
     secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+    assetHost: 'OPTIONAL_CDN_URL'
   },
 },
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -14,11 +14,11 @@ class Store extends BaseStore {
 
     AWS.config.setPromisesDependency( Promise );
 
-    const { accessKeyId, bucket, region, secretAccessKey } = config;
+    const { accessKeyId, bucket, region, secretAccessKey, assetHost } = config;
 
     this.accessKeyId = accessKeyId;
     this.bucket = bucket;
-    this.host = `https://s3${ region === 'us-east-1' ? '' : `-${ region }` }.amazonaws.com/${ bucket }`;
+    this.host = assetHost ? assetHost : `https://s3${ region === 'us-east-1' ? '' : `-${ region }` }.amazonaws.com/${ bucket }`;
     this.region = region;
     this.secretAccessKey = secretAccessKey;
 


### PR DESCRIPTION
Currently this adapter won't accommodate people who wish to use a CDN in front of S3 due to the host name being forced to the normal aws route. It would be cool to offer the ability to pass in a CDN host name. I've added one into the source and into the documentation. This should hopefully widen the reach of the adapter.

Great adapter by the way!