### PR TITLE
style(readme): change to a cleaner usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@ An AWS S3 storage adapter for Ghost 0.10+
 
 ## Installation
 
+```bash
+# Install the module
+npm install ghost-storage-adapter-s3 --save
+
+# Create the adapter link file
+touch ./content/storage/s3/index.js
 ```
-npm install ghost-storage-adapter-s3
-mkdir -p ./content/storage
-cp -r ./node_modules/ghost-storage-adapter-s3 ./content/storage/s3
+
+Inside `./content/storage/s3/index.js` add the following code
+
+```javascript
+'use strict';
+module.exports = require('ghost-storage-adapter-s3');
 ```
 
 ## Configuration


### PR DESCRIPTION
The original method instructed the user to copy the module from the original npm installation path into the project itself. This wasn't so great as it meant we'd then be adding the dependencies to the users ghost project and potentially increasing the project size by quite a bit.

I've changed the method to allow npm to handle the installation of this package, and then we simply require it in and export it as the module. This way the module itself is still controlled by NPM for easy updates in the future, and any deployment / CI system can handle pulling the package and all the dependencies as normal.