### PR TITLE
Support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ storage: {
 }
 ```
 
+### Via environment variables
+
+```
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_DEFAULT_REGION
+GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET
+GHOST_STORAGE_ADAPTER_S3_ASSET_HOST  // optional
+GHOST_STORAGE_ADAPTER_S3_PATH_PREFIX // optional
+```
+
 ## License
 
 [ISC](./LICENSE.md).

--- a/src/index.js
+++ b/src/index.js
@@ -23,12 +23,16 @@ class Store extends BaseStore {
       secretAccessKey
     } = config
 
-    this.accessKeyId = accessKeyId
-    this.bucket = bucket
-    this.host = assetHost || `https://s3${region === 'us-east-1' ? '' : `-${region}`}.amazonaws.com/${bucket}`
-    this.pathPrefix = stripLeadingSlash(pathPrefix || '')
-    this.region = region
-    this.secretAccessKey = secretAccessKey
+    // Compatible with the aws-sdk's default environment variables
+    this.accessKeyId = process.env.AWS_ACCESS_KEY_ID || accessKeyId
+    this.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY || secretAccessKey
+    this.region = process.env.AWS_DEFAULT_REGION || region
+
+    this.bucket = process.env.GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET || bucket
+
+    // Optional configurations
+    this.host = process.env.GHOST_STORAGE_ADAPTER_S3_ASSET_HOST || assetHost || `https://s3${region === 'us-east-1' ? '' : `-${this.region}`}.amazonaws.com/${this.bucket}`
+    this.pathPrefix = stripLeadingSlash(process.env.GHOST_STORAGE_ADAPTER_S3_PATH_PREFIX || pathPrefix || '')
   }
 
   delete (fileName, targetDir) {


### PR DESCRIPTION
Ghost 1.x makes impossible to configure `ghost-storage-adapter-s3` via env. variables as this module use camelCase config property names: `STORAGE__S3_ACCESS_KEY_ID` wouldn't work

Supporting use env. variables from outside would fix this issue.