### PR TITLE
Fix file duplicates not being checked

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,12 @@ class Store extends BaseStore {
     })
   }
 
-  exists (fileName) {
+  exists (fileName, targetDir) {
     return new Promise((resolve, reject) => {
       return this.s3()
         .getObject({
           Bucket: this.bucket,
-          Key: stripLeadingSlash(fileName)
+          Key: stripLeadingSlash(join(targetDir, fileName))
         })
         .promise()
         .then(() => resolve(true))


### PR DESCRIPTION
When Ghost tries to save an image and calls `save()`, the adapter calls `getUniqueFileName()` from [`ghost-storage-base`](https://github.com/TryGhost/Ghost-Storage-Base) to get a unique file name:

https://github.com/colinmeinke/ghost-storage-adapter-s3/blob/8943b5926cb43b2a781766d1e77bc049a6882a37/src/index.js#L86

`getUniqueFileName()` calls `exists()` from the S3 adapter to check if the passed name is occupied. It passes the filename and the directory as arguments:

https://github.com/TryGhost/Ghost-Storage-Base/blob/18527f5b8a2c03361ce41539004aba038e41bf83/BaseStorage.js#L41

However, the S3 adapter reads only the filename parameter (likely because Ghost docs [incorrectly tell to do so](https://docs.ghost.org/v1/docs/using-a-custom-storage-module#section--exists-) – I’ll file an issue in Ghost about this):

https://github.com/colinmeinke/ghost-storage-adapter-s3/blob/8943b5926cb43b2a781766d1e77bc049a6882a37/src/index.js#L55

Because of this, image existence checking is broken. In my tests, when I tried to upload an image with a name that’s already present, the image was silently discarded, and the URL for the already present image was returned.

This PR fixes this issue.
