### PR TITLE
Adding support for local files that just migrated to AWS S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ index.js
 !src/index.js
 node_modules/
 npm-debug.log
+dist

--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@ An AWS S3 storage adapter for Ghost 1.x
 For Ghost 0.10.x and 0.11.x support check out
 [Ghost storage adapter s3 v1.3.0](https://github.com/colinmeinke/ghost-storage-adapter-s3/releases/tag/v1.3.0).
 
+## What's modified by trong-nguyen:
+
+1. Modified the behavior of this adapter when the files were previously stored locally and then moved to AWS S3: it proxies the request to S3 if the path is not recognized as s3 storage.
+
+2. Added the script `install-adapter` as a convenience for user to copy the script over to an already installed Ghost blog. You can either:
+
+```
+cp -r dist/node_modules/* ghost/path/content/adapters/node_modules &&
+cp -r dist/s3 ghost/path/content/adapters/storage/
+```
+
+or:
+
+```
+rsync dist ghost/path/content/adapters
+```
+
+The latter will not alter the current available directory content, which might have other adapters.s
+
 ## Installation
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
     "email": "hello@colinmeinke.com",
     "url": "https://colinmeinke.com"
   },
+  "co-author": {
+    "name": "Trong Nguyen",
+    "email": "nguyentrong@gmail.com",
+    "url": "http://trongn.com"
+  },
   "babel": {
     "plugins": [
       "transform-object-rest-spread",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "bugs": {
-    "url": "https://github.com/colinmeinke/ghost-storage-adapter-s3/issues"
+    "url": "https://github.com/trong-nguyen/ghost-storage-adapter-s3/issues"
   },
   "config": {
     "commitizen": {
@@ -53,7 +53,7 @@
     "snazzy": "^5.0.0",
     "standard": "^8.3.0"
   },
-  "homepage": "https://github.com/colinmeinke/ghost-storage-adapter-s3#readme",
+  "homepage": "https://github.com/trong-nguyen/ghost-storage-adapter-s3#readme",
   "license": "ISC",
   "keywords": [
     "adapter",
@@ -66,7 +66,7 @@
   "name": "ghost-storage-adapter-s3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/colinmeinke/ghost-storage-adapter-s3.git"
+    "url": "https://github.com/trong-nguyen/ghost-storage-adapter-s3.git"
   },
   "scripts": {
     "build": "babel ./src/index.js --out-file ./index.js",
@@ -75,7 +75,11 @@
     "lint": "standard --verbose | snazzy",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "test": "exit 0"
+    "test": "exit 0",
+    "install-adapter-mkdist": "mkdir -p dist/storage/s3",
+    "install-adapter-copy": "cp ./package.json dist && cp ./index.js dist/storage/s3",
+    "install-adapter-dependencies": "npm install --production --prefix $PWD/dist",
+    "install-adapter": "npm run build && npm run install-adapter-mkdist && npm run install-adapter-copy && npm run install-adapter-dependencies && echo 'Done building adapter and dependencies! Copy content in ./dist to your ghost/content/adapters'"
   },
   "version": "0.0.0-semantically-released"
 }

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,1 @@
+nodemon -w src/index.js --exec "npm run build && cp -f index.js ghost/content/adapters/storage/s3/"


### PR DESCRIPTION
If you fall in a situation when you stored your files / images, etc. previously in local disks, and now you want to migrate to S3. Use this version to support requests to files that are not yet (or previously) stored on S3.