### PR TITLE
feat: added acl to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cp -r ./node_modules/ghost-storage-adapter-s3 ./content/adapters/storage/s3
     "endpoint": "YOUR_OPTIONAL_ENDPOINT_URL (only needed for 3rd party S3 providers)",
     "serverSideEncryption": "YOUR_OPTIONAL_SSE (See note 2 below)",
     "forcePathStyle": true,
+    "acl": "YOUR_OPTIONAL_ACL (See note 4 below)",
   }
 }
 ```
@@ -36,6 +37,8 @@ Note 1: Be sure to include "//" or the appropriate protocol within your assetHos
 Note 2: if your s3 bucket enforces SSE use serverSideEncryption with the [appropriate supported](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property) value.
 
 Note 3: if your s3 providers requires path style you can enable it with `forcePathStyle`
+
+Note 4: if you use CloudFront the object ACL does not need to be set to "public-read"
 
 ### Via environment variables
 
@@ -49,6 +52,7 @@ GHOST_STORAGE_ADAPTER_S3_PATH_PREFIX // optional
 GHOST_STORAGE_ADAPTER_S3_ENDPOINT // optional
 GHOST_STORAGE_ADAPTER_S3_SSE // optional
 GHOST_STORAGE_ADAPTER_S3_FORCE_PATH_STYLE // optional
+GHOST_STORAGE_ADAPTER_S3_ACL // optional
 ```
 
 ## AWS Configuration

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ class Store extends BaseStore {
       secretAccessKey,
       endpoint,
       serverSideEncryption,
-      forcePathStyle
+      forcePathStyle,
+      acl
     } = config
 
     // Compatible with the aws-sdk's default environment variables
@@ -36,6 +37,7 @@ class Store extends BaseStore {
     this.endpoint = process.env.GHOST_STORAGE_ADAPTER_S3_ENDPOINT || endpoint || ''
     this.serverSideEncryption = process.env.GHOST_STORAGE_ADAPTER_S3_SSE || serverSideEncryption || ''
     this.s3ForcePathStyle = Boolean(process.env.GHOST_STORAGE_ADAPTER_S3_FORCE_PATH_STYLE) || Boolean(forcePathStyle) || false
+    this.acl = process.env.GHOST_STORAGE_ADAPTER_S3_ACL || acl || 'public-read'
   }
 
   delete (fileName, targetDir) {
@@ -87,7 +89,7 @@ class Store extends BaseStore {
         readFileAsync(image.path)
       ]).then(([ fileName, file ]) => {
         let config = {
-          ACL: 'public-read',
+          ACL: this.acl,
           Body: file,
           Bucket: this.bucket,
           CacheControl: `max-age=${30 * 24 * 60 * 60}`,


### PR DESCRIPTION
Allows changing of the object ACL using either an environment variable or config option.

This is needed for us as we use CloudFront to server our assets and have the new

    Block new public ACLs and uploading public objects (Recommended)

Option enabled on our account for all S3 buckets